### PR TITLE
Theme and a11y fixes

### DIFF
--- a/app/src/main/java/com/togitech/togii/MainActivity.kt
+++ b/app/src/main/java/com/togitech/togii/MainActivity.kt
@@ -83,7 +83,6 @@ fun CountryCodePick() {
                 isNumberValid = isValid
             },
             label = { Text("Test Label") },
-            textStyle = MaterialTheme.typography.body1.copy(color = MaterialTheme.colors.onSurface)
         )
         Spacer(modifier = Modifier.height(10.dp))
 

--- a/app/src/main/java/com/togitech/togii/MainActivity.kt
+++ b/app/src/main/java/com/togitech/togii/MainActivity.kt
@@ -83,6 +83,7 @@ fun CountryCodePick() {
                 isNumberValid = isValid
             },
             label = { Text("Test Label") },
+            textStyle = MaterialTheme.typography.body1.copy(color = MaterialTheme.colors.onSurface)
         )
         Spacer(modifier = Modifier.height(10.dp))
 

--- a/ccp/src/main/java/com/togitech/ccp/component/CountryDialog.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/CountryDialog.kt
@@ -2,6 +2,7 @@ package com.togitech.ccp.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +35,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
@@ -204,10 +208,20 @@ private fun SearchTextField(
     leadingIcon: (@Composable () -> Unit)? = null,
     hint: String = stringResource(id = R.string.search),
 ) {
+    val requester = remember { FocusRequester() }
+
+    LaunchedEffect(
+        key1 = Unit,
+        block = {
+            requester.requestFocus()
+        },
+    )
+
     BasicTextField(
         modifier = modifier
+            .height(48.dp)
             .fillMaxWidth()
-            .padding(horizontal = DEFAULT_ROW_PADDING),
+            .focusRequester(requester),
         value = value,
         onValueChange = onValueChange,
         singleLine = true,
@@ -215,18 +229,27 @@ private fun SearchTextField(
         textStyle = textStyle,
         decorationBox = { innerTextField ->
             Row(
-                Modifier.fillMaxWidth(),
+                Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (leadingIcon != null) leadingIcon()
-                if (value.isEmpty()) {
-                    Text(
-                        text = hint,
-                        maxLines = 1,
-                        style = textStyle.copy(color = textStyle.color.copy(alpha = 0.5f)),
-                    )
+                Box(
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .weight(1f),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = hint,
+                            maxLines = 1,
+                            style = textStyle.copy(color = textStyle.color.copy(alpha = 0.5f)),
+                        )
+                    }
+                    innerTextField()
                 }
-                innerTextField()
             }
         },
     )

--- a/ccp/src/main/java/com/togitech/ccp/component/CountryDialog.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/CountryDialog.kt
@@ -62,6 +62,7 @@ private val DEFAULT_ROW_PADDING = 16.dp
 private const val ROW_PADDING_VERTICAL_SCALING = 1.1f
 private val SEARCH_ICON_PADDING = 5.dp
 private const val HEADER_TEXT_SIZE_MULTIPLE = 1.5
+private val MIN_TAP_DIMENSION = 48.dp
 
 /**
  * @param onDismissRequest Executes when the user tries to dismiss the dialog.
@@ -210,16 +211,13 @@ private fun SearchTextField(
 ) {
     val requester = remember { FocusRequester() }
 
-    LaunchedEffect(
-        key1 = Unit,
-        block = {
-            requester.requestFocus()
-        },
-    )
+    LaunchedEffect(Unit) {
+        requester.requestFocus()
+    }
 
     BasicTextField(
         modifier = modifier
-            .height(48.dp)
+            .height(MIN_TAP_DIMENSION)
             .fillMaxWidth()
             .focusRequester(requester),
         value = value,
@@ -231,13 +229,13 @@ private fun SearchTextField(
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .height(48.dp),
+                    .height(MIN_TAP_DIMENSION),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (leadingIcon != null) leadingIcon()
                 Box(
                     modifier = Modifier
-                        .padding(start = 8.dp)
+                        .padding(start = DEFAULT_ROUNDING)
                         .weight(1f),
                     contentAlignment = Alignment.CenterStart,
                 ) {

--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
@@ -102,7 +102,7 @@ fun TogiCountryCodePicker(
     initialCountryIsoCode: Iso31661alpha2? = null,
     initialCountryPhoneCode: PhoneCode? = null,
     label: @Composable (() -> Unit)? = null,
-    textStyle: TextStyle = MaterialTheme.typography.body1,
+    textStyle: TextStyle = MaterialTheme.typography.body1.copy(color = MaterialTheme.colors.onSurface),
 ) {
     val context = LocalContext.current
     val focusRequester = remember { FocusRequester() }


### PR DESCRIPTION
1. A11y fixes with minimum search tap size of 48dp
2. Fix the sample code with correct color on text style which works on light and dark mode.
3. Add focus requester on search field on country picker
4. Wrap hint and innerTextField inside a box, so that cursor is not at the end of hint.
5. Also remove unnecessary padding on the search field. 

Attached screenshots for light and dark mode.

![Screenshot 2023-10-06 at 3 13 03 PM](https://github.com/jump-sdk/jetpack_compose_country_code_picker_emoji/assets/6739498/6335b6a5-5dea-4f97-962d-1aef700944a7)

![Screenshot 2023-10-06 at 3 12 34 PM](https://github.com/jump-sdk/jetpack_compose_country_code_picker_emoji/assets/6739498/29551032-5981-41ac-a82c-f730b60d9c5d)
