### PR TITLE
Fix modifiers to adjust tap targets

### DIFF
--- a/ccp/src/main/java/com/togitech/ccp/component/CountryDialog.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/CountryDialog.kt
@@ -175,12 +175,12 @@ private fun CountryRowItem(
 ) {
     Row(
         Modifier
+            .clickable(onClick = { onSelect() })
             .padding(
                 horizontal = rowPadding,
                 vertical = rowPadding * ROW_PADDING_VERTICAL_SCALING,
             )
-            .fillMaxWidth()
-            .clickable(onClick = { onSelect() }),
+            .fillMaxWidth(),
         horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCodeDialog.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCodeDialog.kt
@@ -43,7 +43,6 @@ internal fun TogiCodeDialog(
     showCountryCode: Boolean,
     showFlag: Boolean,
     textStyle: TextStyle,
-    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
 
@@ -70,7 +69,7 @@ internal fun TogiCodeDialog(
             },
     ) {
         CountryRow(
-            modifier = modifier,
+            modifier = Modifier.padding(DEFAULT_PADDING),
             showCountryCode = showCountryCode,
             showFlag = showFlag,
             country = country,
@@ -101,11 +100,11 @@ internal fun TogiCodeDialog(
 
 @Composable
 private fun CountryRow(
-    modifier: Modifier = Modifier,
     showCountryCode: Boolean,
     showFlag: Boolean,
     country: CountryData,
     textStyle: TextStyle,
+    modifier: Modifier = Modifier,
 ) = Row(
     modifier = modifier,
     horizontalArrangement = Arrangement.SpaceBetween,

--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCodeDialog.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCodeDialog.kt
@@ -61,7 +61,7 @@ internal fun TogiCodeDialog(
     }
 
     Column(
-        modifier = modifier
+        modifier = Modifier
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
@@ -70,6 +70,7 @@ internal fun TogiCodeDialog(
             },
     ) {
         CountryRow(
+            modifier = modifier,
             showCountryCode = showCountryCode,
             showFlag = showFlag,
             country = country,
@@ -78,7 +79,9 @@ internal fun TogiCodeDialog(
 
         if (isOpenDialog) {
             CountryDialog(
-                modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(DEFAULT_ROUNDING)),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(DEFAULT_ROUNDING)),
                 onDismissRequest = { isOpenDialog = false },
                 onSelect = { countryItem ->
                     onCountryChange(countryItem)
@@ -98,11 +101,13 @@ internal fun TogiCodeDialog(
 
 @Composable
 private fun CountryRow(
+    modifier: Modifier = Modifier,
     showCountryCode: Boolean,
     showFlag: Boolean,
     country: CountryData,
     textStyle: TextStyle,
 ) = Row(
+    modifier = modifier,
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically,
 ) {

--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
@@ -3,7 +3,6 @@ package com.togitech.ccp.component
 import android.util.Log
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -204,7 +203,6 @@ fun TogiCountryCodePicker(
         },
         leadingIcon = {
             TogiCodeDialog(
-                modifier = Modifier.padding(DEFAULT_PADDING),
                 selectedCountry = country,
                 includeOnly = includeOnly,
                 onCountryChange = { countryData ->


### PR DESCRIPTION
Fixes touch targets to entire rows making the click area equal to the row area instead of being smaller.