### PR TITLE
Improve ClearIcon color logic

### DIFF
--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
@@ -222,7 +222,7 @@ fun TogiCountryCodePicker(
                 ClearIconButton(
                     imageVector = clearIcon,
                     colors = colors,
-                    isNumberValid = !showError || isNumberValid ,
+                    isNumberValid = !showError || isNumberValid,
                 ) {
                     phoneNumber = TextFieldValue("")
                     isNumberValid = false

--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
@@ -222,7 +222,7 @@ fun TogiCountryCodePicker(
                 ClearIconButton(
                     imageVector = clearIcon,
                     colors = colors,
-                    isNumberValid = isNumberValid,
+                    isNumberValid = !showError || isNumberValid ,
                 ) {
                     phoneNumber = TextFieldValue("")
                     isNumberValid = false


### PR DESCRIPTION
Fix a small bug on the ClearIcon color.

When `showError` is set to false, ClearIcon doesn't use this value and still display error color.