### PR TITLE
release 2.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Step 2. Add the dependency - n.b. this currently does not support Material 3.
 ```kotlin 
 dependencies {
     implementation("androidx.compose.material:material:1.5.4")
-    implementation("com.github.jump-sdk:jetpack_compose_country_code_picker_emoji:2.2.6")
+    implementation("com.github.jump-sdk:jetpack_compose_country_code_picker_emoji:2.2.7")
 }  
 ```
 

--- a/ccp/build.gradle.kts
+++ b/ccp/build.gradle.kts
@@ -78,7 +78,7 @@ afterEvaluate {
                 groupId = "com.togisoft"
                 artifactId = "jetpack_country_code_picker"
                 // Update version in README when changing below
-                version = "2.2.6"
+                version = "2.2.7"
             }
         }
     }


### PR DESCRIPTION
- Compose version updated
- paparazzi was set to 1.3.1 because the guava version changed on Snapshot