### PR TITLE
Fix crash on Compose 1.7; Update dependencies

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,123 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.20" />
+    <option name="version" value="1.9.25" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.25" />
+    <option name="version" value="2.0.20" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -29,9 +30,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
     namespace = "com.togitech.togii"
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,8 @@ android {
 }
 
 dependencies {
+    val composeBom = platform(libs.androidx.compose.bom)
+    implementation(composeBom)
     implementation(libs.accompanist.systemuicontroller)
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.runtime)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.compose.compiler) apply false
     id("com.android.application") version libs.versions.android.gradle.plugin apply false
     id("com.android.library") version libs.versions.android.gradle.plugin apply false
     id("org.jetbrains.kotlin.android") version libs.versions.kotlin apply false

--- a/ccp/build.gradle.kts
+++ b/ccp/build.gradle.kts
@@ -46,8 +46,11 @@ android {
 }
 
 dependencies {
+    val composeBom = platform(libs.androidx.compose.bom)
     api(libs.kotlinx.immutable)
     api(libs.libphonenumber)
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
     debugImplementation(libs.compose.tooling)
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.compose)

--- a/ccp/build.gradle.kts
+++ b/ccp/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.compose.activity)
     implementation(libs.compose.material)
+    implementation(libs.compose.icons)
     implementation(libs.compose.tooling.preview)
 
     detektPlugins("ru.kode:detekt-rules-compose:1.3.0")

--- a/ccp/build.gradle.kts
+++ b/ccp/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("maven-publish")
     id("io.gitlab.arturbosch.detekt") version libs.versions.detekt.get()
     id("org.jetbrains.dokka")
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.paparazzi)
 }
 
@@ -34,9 +35,6 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
     publishing {
         singleVariant("release") {

--- a/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
+++ b/ccp/src/main/java/com/togitech/ccp/component/TogiCountryCodePicker.kt
@@ -255,7 +255,7 @@ fun TogiCountryCodePicker(
         visualTransformation = phoneNumberTransformation,
         keyboardOptions = keyboardOptions ?: KeyboardOptions.Default.copy(
             keyboardType = KeyboardType.Phone,
-            autoCorrect = true,
+            autoCorrectEnabled = true,
             imeAction = ImeAction.Done,
         ),
         keyboardActions = keyboardActions ?: KeyboardActions(

--- a/ccp/src/main/java/com/togitech/ccp/transformation/PhoneNumberTransformation.kt
+++ b/ccp/src/main/java/com/togitech/ccp/transformation/PhoneNumberTransformation.kt
@@ -76,7 +76,7 @@ class PhoneNumberTransformation(countryCode: String, context: Context) : VisualT
             } else {
                 originalToTransformed.add(index)
             }
-            transformedToOriginal.add(index - specialCharsCount)
+            transformedToOriginal.add(maxOf(index - specialCharsCount, 0))
         }
         originalToTransformed.add(originalToTransformed.maxOrNull()?.plus(1) ?: 0)
         transformedToOriginal.add(transformedToOriginal.maxOrNull()?.plus(1) ?: 0)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.22"
+kotlin = "1.9.25"
 dokka = "1.9.10"
 
 ## SDK Versions
@@ -12,22 +12,24 @@ android-gradle-plugin = "8.2.2"
 gradle-versions = "0.50.0"
 detekt = "1.23.3"
 
-accompanist = "0.34.0"
-androidx-activity-compose = "1.8.2"
-androidx-core = "1.12.0"
-androidx-lifecycle = "2.7.0"
-androidx-test-junit = "1.1.5"
+accompanist = "0.36.0"
+androidx-activity-compose = "1.9.2"
+androidx-core = "1.13.1"
+androidx-lifecycle = "2.8.6"
+androidx-test-junit = "1.2.1"
 
 # update version in README when changing below
-compose = "1.6.0"
+compose = "1.7.2"
+# original compose version that works: 1.6.0
 # https://androidx.dev/storage/compose-compiler/repository/
 # https://developer.android.com/jetpack/androidx/releases/compose-compiler
-composeCompiler = "1.5.8"
+composeCompiler = "1.5.15"
+# original composeCompiler version that works: 1.5.8
 
 kotlinx-coroutines = "1.7.3"
 kotlinx-collections-immutable = "0.3.7"
 
-libphonenumber = "8.13.28"
+libphonenumber = "8.13.35"
 
 junit = "4.13.2"
 robolectric = "4.11.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ targetSdk = "34"
 compileSdk = "34"
 
 # Dependencies
-android-gradle-plugin = "8.2.2"
+android-gradle-plugin = "8.6.0"
 gradle-versions = "0.50.0"
 detekt = "1.23.3"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,18 +13,13 @@ gradle-versions = "0.50.0"
 detekt = "1.23.3"
 
 accompanist = "0.36.0"
+androidx-compose-bom = "2024.09.02"
 androidx-activity-compose = "1.9.2"
 androidx-core = "1.13.1"
 androidx-lifecycle = "2.8.6"
 androidx-test-junit = "1.2.1"
 
-# update version in README when changing below
-compose = "1.7.2"
-# original compose version that works: 1.6.0
-# https://androidx.dev/storage/compose-compiler/repository/
-# https://developer.android.com/jetpack/androidx/releases/compose-compiler
 composeCompiler = "1.5.15"
-# original composeCompiler version that works: 1.5.8
 
 kotlinx-coroutines = "1.7.3"
 kotlinx-collections-immutable = "0.3.7"
@@ -38,6 +33,7 @@ paparazzi = "1.3.1"
 [libraries]
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-lifecycle-compose = {module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle"}
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
@@ -45,13 +41,12 @@ androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-junit" }
 
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose-icons = { module = "androidx.compose.material:material-icons-core", version.ref = "compose" }
-compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+
+compose-material = { module = "androidx.compose.material:material" }
+compose-icons = { module = "androidx.compose.material:material-icons-core" }
+compose-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+compose-ui = { module = "androidx.compose.ui:ui" }
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,15 +17,11 @@ androidx-compose-bom = "2024.09.02"
 androidx-activity-compose = "1.9.2"
 androidx-core = "1.13.1"
 androidx-lifecycle = "2.8.6"
-androidx-test-junit = "1.2.1"
-
-kotlinx-coroutines = "1.7.3"
 kotlinx-collections-immutable = "0.3.7"
 
 libphonenumber = "8.13.35"
 
 junit = "4.13.2"
-robolectric = "4.11.1"
 paparazzi = "1.3.1"
 
 [libraries]
@@ -36,7 +32,6 @@ androidx-lifecycle-compose = {module = "androidx.lifecycle:lifecycle-runtime-com
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
-androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-junit" }
 
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 
@@ -46,20 +41,13 @@ compose-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-ui = { module = "androidx.compose.ui:ui" }
 
-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-
 libphonenumber = { module = "io.michaelrocks:libphonenumber-android", version.ref = "libphonenumber" }
 
 kotlinx-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-roboelectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
-org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 gradleVersions = { id = "com.github.ben-manes.versions", version.ref = "gradle-versions" }
-kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.25"
+kotlin = "2.0.20"
 dokka = "1.9.10"
 
 ## SDK Versions
@@ -18,8 +18,6 @@ androidx-activity-compose = "1.9.2"
 androidx-core = "1.13.1"
 androidx-lifecycle = "2.8.6"
 androidx-test-junit = "1.2.1"
-
-composeCompiler = "1.5.15"
 
 kotlinx-coroutines = "1.7.3"
 kotlinx-collections-immutable = "0.3.7"
@@ -60,6 +58,8 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 roboelectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
+org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 gradleVersions = { id = "com.github.ben-manes.versions", version.ref = "gradle-versions" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ compose-activity = { module = "androidx.activity:activity-compose", version.ref 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+compose-icons = { module = "androidx.compose.material:material-icons-core", version.ref = "compose" }
 compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
After updating to Jetpack Compose 1.7, this library would lead to a crash (#65) in our app after typing about 7 or 8 digits (for a Canadian / US number, at least):

```
Process: com.togitech.togii, PID: 15552
java.lang.IllegalStateException: OffsetMapping.transformedToOriginal returned invalid mapping: 0 -> -1 is not in range of original text [0, 8]
```

I suspect this occurs when a number starts to be formatted-as-you-type with parenthesis. E.g.:`416555` would be formatted as `416-555`, while `4165550` would be formatted as `(416)-555-0`.

I suspect that previous versions of Compose treated negative indexes passed to `transformedToOriginal` as undefined behaviour, but in 1.7 it's more defined and leads to a crash.

In any case, my colleague came up with a quick fix by clamping `-1` to `0`. Not sure if this is the correct fix, but this has fixed the crash for us, and has had no negative outcomes in our code.

While the fix was one line of code, it was necessary to increase the Jetpack Compose version to at least 1.7. However, in addition to updating Jetpack Compose to 1.7, we've also updated the library to use Kotlin 2.0; to use the Compose BOM (instead of defining individual libraries/versions); and updated some other dependencies.